### PR TITLE
Move logic to backend separate endpoints

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -44,18 +44,30 @@ export default function Settings() {
 
   // Save settings to localStorage
   const saveSettings = () => {
-    localStorage.setItem("difficulty", difficulty);
-    localStorage.setItem("speechRate", speechRate.toString());
-    localStorage.setItem("selectedVoiceURI", selectedVoiceURI);
-    localStorage.setItem("autoReplay", autoReplay.toString());
-    localStorage.setItem("matchStrictness", matchStrictness);
-    localStorage.setItem("timeWeight", timeWeight.toString());
-
+    // Replace localStorage with API calls
+const saveSettings = async () => {
+  try {
+    await apiRequest('PATCH', '/api/user/settings', {
+      speechRate,
+      selectedVoiceURI,
+      autoReplay,
+      matchStrictness,
+      timeWeight,
+      difficulty
+    });
+    
     toast({
       title: "Settings saved",
-      description: "Your preferences have been updated.",
-      variant: "default",
+      description: "Your preferences have been synced.",
     });
+  } catch (error) {
+    toast({
+      title: "Save failed", 
+      description: "Could not save settings.",
+      variant: "destructive"
+    });
+  }
+};
   };
 
   // Export user data as JSON file

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1315,7 +1315,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Update user streak and score 
   app.post("/api/user/streak", requireAuth, async (req, res) => {
     try {
-      const userId = req.user?.id;
+      const userId = req.authenticatedUserId;
+
       if (!userId) {
         return res.status(401).json({ message: "Unauthorized" });
       }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp, varchar } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, timestamp, varchar, numeric } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 import { relations } from "drizzle-orm";
@@ -18,6 +18,12 @@ export const users = pgTable("users", {
   highestScore: integer("highest_score").default(0), // Highest score ever achieved
   lastPracticeDate: timestamp("last_practice_date"), // To track daily streaks
   createdAt: timestamp("created_at").defaultNow(),
+  speechRate: numeric("speech_rate").default("1.0"),
+  selectedVoiceURI: text("selected_voice_uri"),
+  autoReplay: boolean("auto_replay").default(false),
+  matchStrictness: text("match_strictness").default("moderate"),
+  timeWeight: integer("time_weight").default(3),
+  difficulty: text("difficulty").default("beginner")
 });
 
 export const insertUserSchema = createInsertSchema(users).pick({


### PR DESCRIPTION
This is on top of James's google sign in fix branch, for easier development.

Purpose: Aims to move as much generation and validation code to the backend as possible.

Goal 1:
Move AI-related components to the backend for greater ease of debugging.

Goal 2:
Cleanup code, separate into multiple files instead of one massive router.ts